### PR TITLE
Add VA multiplier checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
                 <form id="va-to-amps-form" onsubmit="return false;">
                     <label for="va">Volt-Amperes (VA):</label>
                     <input type="number" id="va" step="0.01" required>
+                    <div class="va-multiplier">
+                        <label><input type="checkbox" id="va-125" value="1.25"> 125%</label>
+                        <label><input type="checkbox" id="va-175" value="1.75"> 175%</label>
+                        <label><input type="checkbox" id="va-250" value="2.5"> 250%</label>
+                    </div>
 
                     <label for="voltage2">System Voltage:</label>
                     <select id="voltage2">

--- a/main.js
+++ b/main.js
@@ -9,6 +9,8 @@ function openCalc(evt, calcName) {
   evt.currentTarget.className += " active";
 }
 
+let currentMultiplier = 1;
+
 document.addEventListener('DOMContentLoaded', () => {
   ['amps', 'va'].forEach(id => {
     document.getElementById(id).addEventListener('keydown', event => {
@@ -23,6 +25,19 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById(id).addEventListener('change', () => {
       id === 'voltage1' ? calculateAmpsToVA() : calculateVAToAmps();
     });
+  });
+
+  document.querySelectorAll('.va-multiplier input[type="checkbox"]').forEach(cb => {
+    cb.addEventListener('change', () => toggleVAMultiplier(cb));
+  });
+
+  document.getElementById('va').addEventListener('input', () => {
+    const input = document.getElementById('va');
+    if (currentMultiplier !== 1) {
+      input.dataset.baseVa = parseFloat(input.value) / currentMultiplier || 0;
+    } else {
+      input.dataset.baseVa = input.value;
+    }
   });
 });
 
@@ -89,4 +104,29 @@ function copyAWG() {
   navigator.clipboard.writeText(awgConfig).catch(err => {
     console.error('Failed to copy: ', err);
   });
+}
+
+function toggleVAMultiplier(checkbox) {
+  const vaInput = document.getElementById('va');
+
+  if (checkbox.checked) {
+    document.querySelectorAll('.va-multiplier input[type="checkbox"]').forEach(cb => {
+      if (cb !== checkbox) cb.checked = false;
+    });
+
+    if (!vaInput.dataset.baseVa) {
+      vaInput.dataset.baseVa = vaInput.value || 0;
+    }
+
+    const base = parseFloat(vaInput.dataset.baseVa) || 0;
+    currentMultiplier = parseFloat(checkbox.value);
+    vaInput.value = (base * currentMultiplier).toFixed(2);
+  } else {
+    const base = parseFloat(vaInput.dataset.baseVa || vaInput.value) || 0;
+    vaInput.value = base;
+    currentMultiplier = 1;
+    delete vaInput.dataset.baseVa;
+  }
+
+  calculateVAToAmps();
 }

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,15 @@ input, select, button {
   width: 100%;
   padding: 5px;
 }
+
+.va-multiplier input[type="checkbox"] {
+  width: auto;
+  display: inline-block;
+  margin-right: 10px;
+}
+.va-multiplier label {
+  margin-right: 10px;
+}
 button {
   background-color: #4CAF50;
   color: white;


### PR DESCRIPTION
## Summary
- add multiplier checkboxes for `VA to Amps`
- support mutually exclusive 125%, 175%, and 250% selections
- update JS to handle multiplier logic and recalculate automatically
- tweak styles so checkboxes display inline

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6849eb525f58832fbbb5efd792c26351